### PR TITLE
Plot window summary statistics; compare them to simulation summary stats

### DIFF
--- a/workflow/config/AraTha_2epoch_cnn.yaml
+++ b/workflow/config/AraTha_2epoch_cnn.yaml
@@ -1,7 +1,7 @@
 # --- top level arguments are ALWAYS REQUIRED --- #
 
 # change this to the project directory you want to use
-project_dir: "/sietch_colab/natep/popgensbi_snakemake/AraTha_2epoch"
+project_dir: "/home/adkern/popgensbi_snakemake/AraTha_2epoch"
 
 cpu_resources:
   runtime: "2h"

--- a/workflow/prediction_workflow.smk
+++ b/workflow/prediction_workflow.smk
@@ -31,6 +31,7 @@ VCF_DIR = os.path.join(PROJECT_DIR, VCF_PREFIX)
 TENSOR_DIR = os.path.join(VCF_DIR, "tensors")
 TREE_DIR = os.path.join(VCF_DIR, "trees")
 PLOT_DIR = os.path.join(VCF_DIR, "plots")
+SIM_ZARR = os.path.join(PROJECT_DIR, "tensors","zarr")
 
 # Divvy up windows into chunks
 N_CHUNK = config["prediction"].get("n_chunk")
@@ -47,7 +48,7 @@ scattergather:
 rule predict_all:
     input:
         predictions = os.path.join(PLOT_DIR, "posteriors-across-windows.png"),
-
+        tree_stats_hist = os.path.join(PLOT_DIR, "tree_stats_hist.png"),
 
 rule process_all:
     input:
@@ -108,6 +109,23 @@ rule infer_batch:
         output_dir = TREE_DIR,
     script:
         "scripts/infer_batch.py"
+
+rule plot_tree_stats:
+    message:
+        "Plotting summary statistics of tree files..."
+    input:
+        zarr = rules.setup_prediction.output.zarr,
+        infer_done = gather.split(os.path.join(TREE_DIR, "{scatteritem}-infer.done")),
+    output:
+        tree_stats_hist = os.path.join(PLOT_DIR, "tree_stats_hist.png"),
+
+    params:
+        tree_dir = TREE_DIR,
+        plot_dir = PLOT_DIR,
+        simulation_zarr = SIM_ZARR,
+    threads: 10
+    resources: **CPU_RESOURCES
+    script: "scripts/plot_tree_stats.py"
 
 
 rule process_batch:

--- a/workflow/scripts/plot_tree_stats.py
+++ b/workflow/scripts/plot_tree_stats.py
@@ -1,0 +1,84 @@
+import os
+import zarr
+import tskit
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+import pandas as pd
+from tqdm import tqdm
+from multiprocessing import Pool
+import glob
+
+# get number of windows from glob
+# TODO: maybe change this from glob to look at the zarr directly 
+tree_files = glob.glob(os.path.join(snakemake.params.tree_dir, "*.trees"))
+n_windows = len(tree_files)
+
+
+# use multiprocessing to calculate summary statistics
+num_workers = snakemake.threads
+
+def process_tree(i):
+    tree_path = os.path.join(snakemake.params.tree_dir, f"{i}.trees")
+    ts = tskit.load(tree_path)
+    # calculate and return summary statistics for the tree
+    return [
+        ts.segregating_sites(span_normalise=False), 
+        ts.diversity(mode="site", span_normalise=True),
+        ts.Tajimas_D(),
+    ]
+# Create a pool of workers and process the jobs in parallel
+with Pool(processes=num_workers) as pool:
+    # Using tqdm to display progress; pool.imap preserves the order of the results
+    results = list(tqdm(pool.imap(process_tree, range(n_windows)),
+                        total=n_windows,
+                        desc="Processing trees"))
+
+stats = np.array(results)  
+df = pd.DataFrame(stats, columns=["segregating_sites", "diversity", "Tajimas_D"])
+
+# open simulation zarr file; get simulation stats
+z = zarr.open(snakemake.params.simulation_zarr, mode="r")
+sim_stats = np.array([
+    z.segregating_sites[:],
+    z.diversity[:],
+    z.Tajimas_D[:]
+]).T  # Transpose to get shape (N, 3)
+sim_df = pd.DataFrame(sim_stats, columns=["segregating_sites", "diversity", "Tajimas_D"])
+
+# plot histograms of tree stats vs simulation stats
+fig, axs = plt.subplots(1, 3, figsize=(12, 4))
+columns = ["segregating_sites", "diversity", "Tajimas_D"]
+
+for i, col in enumerate(columns):
+    # primary axis for tree statistics
+    ax1 = axs[i]
+    # secondary axis for simulation statistics
+    ax2 = ax1.twinx()
+
+    # Plot the tree data on the primary y-axis
+    sns.histplot(df[col], 
+                 ax=ax1, 
+                 color='C0', 
+                 label='Trees', 
+                 alpha=0.5)
+    # Plot the simulation data on the secondary y-axis
+    sns.histplot(sim_df[col], 
+                 ax=ax2, 
+                 color='C1', 
+                 label='Simulation', 
+                 alpha=0.5)
+
+    # Label the y-axes appropriately
+    ax1.set_ylabel('Tree counts', color='C0')
+    ax2.set_ylabel('Simulation counts', color='C1')
+    ax1.set_xlabel(col)
+
+    # Optionally, add legends to identify the plots.
+    ax1.legend(loc='upper left')
+    ax2.legend(loc='upper right')
+
+plt.tight_layout()
+plt.savefig(snakemake.output.tree_stats_hist)
+plt.clf()
+

--- a/workflow/training_workflow.smk
+++ b/workflow/training_workflow.smk
@@ -66,6 +66,10 @@ rule analyze_all:
         at_prior_mean = os.path.join(PLOT_DIR, "posterior_at_prior_mean.png"),
         at_prior_low = os.path.join(PLOT_DIR, "posterior_at_prior_low.png"),
         at_prior_high = os.path.join(PLOT_DIR, "posterior_at_prior_high.png"),
+        sim_stats = os.path.join(PLOT_DIR, "simulation_stats.png"),
+        sim_pairplot = os.path.join(PLOT_DIR, "stats_vs_params_pairplot.png"),
+        sim_heatmaps = os.path.join(PLOT_DIR, "stats_heatmaps.png"),
+
 
 
 rule train_all:
@@ -240,6 +244,7 @@ rule plot_simulation_stats:
         "Plotting simulation stats..."
     input:
         zarr = rules.setup_training.output.zarr,
+        simulate_done = rules.simulate_all.input,
     output:
         stats_hist = os.path.join(PLOT_DIR, "simulation_stats.png"),
         stats_vs_params_pairplot = os.path.join(PLOT_DIR, "stats_vs_params_pairplot.png"),


### PR DESCRIPTION
this PR adds a rule to the prediction workflow that plots simple summaries of diversity for the inferred tree sequences and compares them to the same summaries obtained from the training simulations

A couple notes:
- summary stats from training simulations are now stored in the associated zarr
- diversity has been switched to 'site' mode for summary calculation
- the script `plot_tree_stats.py` is reading from the `trees` dir with a `glob` -- this could throw off a user in the future